### PR TITLE
Rolling

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: puntr
 Type: Package
 Title: Analysis of Punting
-Version: 1.1.8
+Version: 1.2.0
 Authors@R: c(
     person("Dennis", "Brookner", role = c("aut", "cre"), email = "debrookner@gmail.com"),
     person("Raphael", "LadenGuindon", role = "aut"))
@@ -12,7 +12,6 @@ URL: https://github.com/Puntalytics/puntr
 Encoding: UTF-8
 LazyData: true
 Imports:
-    cfbscrapR (>= 1.0.2),
     dplyr,
     forcats,
     ggimage,
@@ -26,5 +25,4 @@ Imports:
     stringr,
     tibble
 RoxygenNote: 7.1.1
-Remotes:  
-    saiemgilani/cfbscrapR
+

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,6 +23,7 @@ Imports:
     purrr,
     readr,
     stringr,
-    tibble
+    tibble,
+    tictoc
 RoxygenNote: 7.1.1
 

--- a/R/calculate.R
+++ b/R/calculate.R
@@ -7,10 +7,11 @@
 # Inputs and outputs a dataframe "punts"
 #' Calculate metrics
 #'
-#' @description This function adds all Puntalytics metrics to your punting data: RERUN, SHARP, SHARPnet, and SHARP_RERUN
-#' (plus open-field and pin-deep versions of the 3 SHARPs) as well as average and cumulative EPA (our custom EPA metric.) This function will continue to be updated as new metrics are added.
+#' @description This function adds all Puntalytics metrics to your punting data: RERUN, SHARP, SHARPnet and SHARP_RERUN
+#' (plus open-field and pin-deep versions of the 3 SHARPs) as well as average and cumulative EPA (our custom EPA metric.)
+#' This function will continue to be updated as new metrics are added.
 #' Currently, functions for calculating individual metrics are for internal use only, and not exported.
-#' @param punts The already-processed play-by-play punting data to which metrics will be added
+#' @param punts The already-processed play-by-play punting data to which metrics will be added. Must contain at least three seasons and 1000 punts.
 #' @return A tibble \code{punts} with the calculated metrics added
 #' @examples
 #' \dontrun{
@@ -19,12 +20,136 @@
 #' @export
 calculate_all <- function(punts) {
 
+  # Check the size of the data and throw and error and/or warning
+  if (nrow(punts) < 1000) {
+    stop(
+"Calculating with fewer than 1000 punts is no longer supported by `puntr`.
+Add more punts and/or seasons to your dataframe for accurate calculation")
+  } else if (max(punts$season) - min(punts$season) <= 1) {
+    stop(
+"Calculating statistics using only one or two seasons is no longer supported by `puntr`.
+Use at least three seasons to your dataframe for best results."
+    )
+  }
+
+  # Do all pre-nesting processing ####
+  # RERUN-related processing
   punts <- punts %>%
-    calculate_rerun() %>%
-    calculate_sharp() %>%
-    dplyr::mutate(returned_pd = dplyr::if_else(PD==1, returned, NA_real_)) %>%
-    dplyr::mutate(returned_of = dplyr::if_else(PD==0, returned, NA_real_)) %>%
-    calculate_punt_epa()
+    dplyr::mutate(returned = purrr::pmap_dbl(list(punt_out_of_bounds==0 &
+                                                    punt_downed==0 &
+                                                    punt_fair_catch==0 &
+                                                    touchback==0, 1, 0), dplyr::if_else)) %>%
+    dplyr::mutate(return_yards_r = purrr::pmap_dbl(list(returned==1, return_yards, NA_real_), dplyr::if_else)) %>%
+    dplyr::mutate(kick_distance_r = purrr::pmap_dbl(list(returned==1, GrossYards, NA_real_), dplyr::if_else))
+
+  # EPA-related processing
+  ep_ref <- url('https://raw.githubusercontent.com/Puntalytics/puntr-data/master/data/fourth_down_ep_reference.csv') %>%
+    readr::read_csv(col_types = 'id')
+  ep_ref_after <- url('https://raw.githubusercontent.com/Puntalytics/puntr-data/master/data/first_down_ep_reference.csv') %>%
+    readr::read_csv(col_types = 'id') %>%
+    dplyr::rename(YardLineAfter_For_Opponent = YardsFromOwnEndZone)
+
+  # declare models
+  rerun_model <- function(input) {
+    loess(formula = return_yards_r ~ kick_distance_r, data = input, span=0.65, na.action = na.exclude)
+  }
+  sharp_model <- function(input) {
+    loess(formula = GrossYards ~ YardsFromOwnEndZone, data = input, span=0.8, na.action = na.exclude)
+  }
+  sharpnet_model <- function(input) {
+    loess(formula = NetYards ~ YardsFromOwnEndZone, data = input, span=0.9, na.action = na.exclude)
+  }
+  sharprerun_model <- function(input) {
+    loess(formula = RERUN ~ YardsFromOwnEndZone, data = input, span=0.9, na.action = na.exclude)
+  }
+  epa_model <- function(input) {
+    loess(formula = punt_epa ~ YardsFromOwnEndZone, data = input, na.action = na.exclude)
+  }
+
+  # roll_join and compute rerun
+  punts_roll <- punts %>%
+    roll_join() %>%
+    # compute return_smooth and RERUN
+    dplyr::mutate(r_model = purrr::map(data_all$data, rerun_model)) %>%
+    dplyr::mutate(return_smooth = purrr::pmap(list(r_model, data), predict)) %>%
+
+    tidyr::unnest(c(data, return_smooth)) %>%
+    dplyr::mutate(RERUN = purrr::pmap_dbl(list(returned==1,
+                                               kick_distance_r - return_smooth, GrossYards),
+                                          dplyr::if_else)) %>%
+    # roll_join again and compute SHARP and variants
+    dplyr::select(-c(roll1, roll2, data_roll1, data_roll2, data_all)) %>%
+    roll_join() %>%
+    dplyr::mutate(model = purrr::map(data_all$data, sharp_model)) %>%
+    dplyr::mutate(yard_smooth = purrr::pmap(list(model, data), predict)) %>%
+
+    dplyr::mutate(model_net = purrr::map(data_all$data, sharpnet_model)) %>%
+    dplyr::mutate(yard_smooth_net = purrr::pmap(list(model_net, data), predict)) %>%
+
+    dplyr::mutate(model_rerun = purrr::map(data_all$data, sharprerun_model)) %>%
+    dplyr::mutate(yard_smooth_rerun = purrr::pmap(list(model_rerun, data), predict)) %>%
+
+    tidyr::unnest(c(data, yard_smooth, yard_smooth_net, yard_smooth_rerun)) %>%
+
+    dplyr::mutate(SHARP = GrossYards/yard_smooth * 100) %>%
+    dplyr::mutate(SHARP_PD = purrr::pmap_dbl(list(PD==1, SHARP, NA_real_), dplyr::if_else)) %>%
+    dplyr::mutate(SHARP_OF = purrr::pmap_dbl(list(PD==0, SHARP, NA_real_), dplyr::if_else)) %>%
+
+    dplyr::mutate(SHARPnet = NetYards/yard_smooth_net * 100) %>%
+    dplyr::mutate(SHARPnet_PD = purrr::pmap_dbl(list(PD==1, SHARPnet, NA_real_), dplyr::if_else)) %>%
+    dplyr::mutate(SHARPnet_OF = purrr::pmap_dbl(list(PD==0, SHARPnet, NA_real_), dplyr::if_else)) %>%
+
+    dplyr::mutate(SHARP_RERUN = RERUN/yard_smooth_rerun * 100) %>%
+    dplyr::mutate(SHARP_RERUN_PD = purrr::pmap_dbl(list(PD==1, SHARP_RERUN, NA_real_), dplyr::if_else)) %>%
+    dplyr::mutate(SHARP_RERUN_OF = purrr::pmap_dbl(list(PD==0, SHARP_RERUN, NA_real_), dplyr::if_else)) %>%
+
+    dplyr::left_join(ep_ref, by = "YardsFromOwnEndZone") %>%
+    dplyr::rename(ep_before = fourth_down_ep) %>%
+    dplyr::mutate(YardLineAfter_For_Opponent = 100 - round((YardsFromOwnEndZone + RERUN))) %>%
+    dplyr::left_join(ep_ref_after, by = "YardLineAfter_For_Opponent") %>%
+    dplyr::rename(ep_after = first_down_ep) %>%
+    dplyr::mutate(ep_after = -ep_after) %>%
+    dplyr::mutate(punt_epa = ep_after - ep_before) %>%
+
+    # roll_join a third time and compute EPA
+    dplyr::select(-c(roll1, roll2, data_roll1, data_roll2, data_all)) %>%
+
+    roll_join() %>%
+    dplyr::mutate(model_e = purrr::map(data_all$data, epa_model)) %>%
+    dplyr::mutate(ea_punt_expected_epa = purrr::pmap(list(model_e, data), predict)) %>%
+
+    tidyr::unnest(c(data, ea_punt_expected_epa)) %>%
+
+    dplyr::mutate(ea_punt_epa_above_expected = punt_epa - ea_punt_expected_epa) %>%
+    dplyr::mutate(pEPA = ea_punt_epa_above_expected) %>%
+
+    dplyr::ungroup()
+
+  return(punts_roll)
+}
+
+roll_join <- function(punts) {
+
+  min_season <- min(punts$season)
+
+  # assign associated seasons for rolling averages
+  punts <- punts %>%
+    dplyr::group_by(season) %>%
+    tidyr::nest()
+
+  punts <- punts %>%
+    dplyr::mutate(roll1 = dplyr::case_when(season == min_season ~ season+1,
+                                           season == (min_season + 1) ~ season+1,
+                                           season > (min_season + 1) ~ season-1)) %>%
+    dplyr::mutate(roll2 = dplyr::case_when(season == min_season ~ season+2,
+                                           season == (min_season + 1) ~ season-1,
+                                           season > (min_season + 1) ~ season-2)) %>%
+    dplyr::left_join(punts, by = c('roll1' = 'season'), suffix = c('', '_roll1')) %>%
+    dplyr::left_join(punts, by = c('roll2' = 'season'), suffix = c('', '_roll2')) %>%
+    # bind seasons with their rolling buddies
+    dplyr::mutate(data_all =
+                    dplyr::bind_rows(list(data, data_roll1, data_roll2)) %>%
+                    tidyr::nest(data=dplyr::everything()))
 
   return(punts)
 }

--- a/R/import.R
+++ b/R/import.R
@@ -19,10 +19,13 @@
 #' @export
 import_punts <- function(years, local = FALSE, path = NULL) {
   if(local == TRUE) {
+    message(glue("puntr::import_punts - Importing locally from {path}"))
     punts <- years %>%
       purrr::map_df(import_local_season, path)
     return(punts)
   } else if(local == FALSE) {
+    message("puntr::import_punts - Importing from https://raw.githubusercontent.com/Puntalytics/puntr-data/master/data/
+For faster import, clone this repo locally and use local = TRUE")
     punts <- years %>%
       purrr::map_df(import_one_season, 'https://raw.githubusercontent.com/Puntalytics/puntr-data/master/data/punts_')
     return(punts)

--- a/man/calculate_all.Rd
+++ b/man/calculate_all.Rd
@@ -7,14 +7,15 @@
 calculate_all(punts)
 }
 \arguments{
-\item{punts}{The already-processed play-by-play punting data to which metrics will be added}
+\item{punts}{The already-processed play-by-play punting data to which metrics will be added. Must contain at least three seasons and 1000 punts.}
 }
 \value{
 A tibble \code{punts} with the calculated metrics added
 }
 \description{
-This function adds all Puntalytics metrics to your punting data: RERUN, SHARP, SHARPnet, and SHARP_RERUN
-(plus open-field and pin-deep versions of the 3 SHARPs) as well as average and cumulative EPA (our custom EPA metric.) This function will continue to be updated as new metrics are added.
+This function adds all Puntalytics metrics to your punting data: RERUN, SHARP, SHARPnet and SHARP_RERUN
+(plus open-field and pin-deep versions of the 3 SHARPs) as well as average and cumulative EPA (our custom EPA metric.)
+This function will continue to be updated as new metrics are added.
 Currently, functions for calculating individual metrics are for internal use only, and not exported.
 }
 \examples{


### PR DESCRIPTION
`calculate_all()` now requires at least 3 seasons and 1000 punts to be present in the dataframe, and then computes stats over 3-year windows. This is for better stability, as well as the ability to accurately compute statistics on in-progress seasons.

`calculate_all()` and `import_punts()` also now print messages describing their progress. `calculate_all()` additionally times each set of calculations using `tictoc` (a new dependency).