### PR TITLE
Revamped summary functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: puntr
 Type: Package
 Title: Analysis of Punting
-Version: 1.2.1
+Version: 1.3
 Authors@R: c(
     person("Dennis", "Brookner", role = c("aut", "cre"), email = "debrookner@gmail.com"),
     person("Raphael", "LadenGuindon", role = "aut"))
@@ -26,4 +26,6 @@ Imports:
     tibble,
     tictoc
 RoxygenNote: 7.1.1
-
+Suggests: 
+    testthat (>= 3.0.0)
+Config/testthat/edition: 3

--- a/R/import.R
+++ b/R/import.R
@@ -27,7 +27,7 @@ import_punts <- function(years, local = FALSE, path = NULL) {
     #message("puntr::import_punts - Importing from https://raw.githubusercontent.com/Puntalytics/puntr-data/master/data/
 #For faster import, clone this repo locally and use local = TRUE")
     punts <- years %>%
-      purrr::map_df(import_one_season, 'https://raw.githubusercontent.com/Puntalytics/puntr-data/master/data/punts_')
+      purrr::map_df(import_one_season, 'https://github.com/mlounsberry/Punt-Charting-2021/blob/main/Punt-Data/2021_01_DAL_TB.csv')
     return(punts)
   } else { stop("'local' must be TRUE or FALSE")}
 

--- a/R/import.R
+++ b/R/import.R
@@ -19,15 +19,15 @@
 #' @export
 import_punts <- function(years, local = FALSE, path = NULL) {
   if(local == TRUE) {
-    #message(glue("puntr::import_punts - Importing locally from {path}"))
+    message(glue("puntr::import_punts - Importing locally from {path}"))
     punts <- years %>%
       purrr::map_df(import_local_season, path)
     return(punts)
   } else if(local == FALSE) {
-    #message("puntr::import_punts - Importing from https://raw.githubusercontent.com/Puntalytics/puntr-data/master/data/
-#For faster import, clone this repo locally and use local = TRUE")
+    message("puntr::import_punts - Importing from https://raw.githubusercontent.com/Puntalytics/puntr-data/master/data/
+            For faster import, clone this repo locally and use local = TRUE")
     punts <- years %>%
-      purrr::map_df(import_one_season, 'https://github.com/mlounsberry/Punt-Charting-2021/blob/main/Punt-Data/2021_01_DAL_TB.csv')
+      purrr::map_df(import_one_season, 'https://raw.githubusercontent.com/Puntalytics/puntr-data/master/data/punts_')
     return(punts)
   } else { stop("'local' must be TRUE or FALSE")}
 

--- a/R/mini.R
+++ b/R/mini.R
@@ -1,22 +1,23 @@
 ###|
-###| "Mini" section
+###| "Mini" section (OLD VERSION)
 ###| Create a dataframe where each punter appears once
 ###|
 
 #' Summarize data for players
 #' @description This function is essentially a convenient wrapper for \code{dplyr::summarise}
-#' which includes all of the relevant columns from a \code{puntr}-style data frame. It is unfortunately not customizable beyond the setting of a
-#' minimum number of punts to be included; if you have additional parameters you'd like to be summarised, the easiest thing would be to call \code{summarise} yourself.
-#' For comparison of punter seasons, see \code{puntr::create_miniY}; for comparison of punter games, see \code{puntr::create_miniG}.
+#' which includes all of the relevant columns from a \code{puntr}-style data frame.
+#' NOTE: \code{puntr::create_mini}, \code{puntr::create_miniY}, and \code{puntr::create_miniG} are being phased out
+#' in favor of \code{puntr::by_punters}, \code{puntr::by_punter_seasons}, and \code{puntr::by_punter_games}
 #' @param punts The play-by-play punting data to be summarized
 #' @param threshold The minimum number of career punts needed to be included, defaults to 64
+#' @param ... Any additional arguments will be passed through to \code{dplyr::summarise}
 #' @return A tibble \code{mini} where each row is a punter and each column is a stat
 #' @examples
 #' \dontrun{
 #' create_mini(punts)
 #' }
 #' @export
-create_mini <- function(punts, threshold=64) {
+create_mini <- function(punts, ..., threshold=64) {
 
   mini <- punts %>%
     dplyr::group_by(punter_player_name) %>%
@@ -34,18 +35,16 @@ create_mini <- function(punts, threshold=64) {
                      SHARP_RERUN = mean(SHARP_RERUN),
                      SHARP_RERUN_OF = mean(SHARP_RERUN_OF, na.rm = TRUE),
                      SHARP_RERUN_PD = mean(SHARP_RERUN_PD, na.rm = TRUE),
-                     # Punt_epa_avg = mean(punt_epa),
-                     # Punt_epa_tot = sum(punt_epa),
-                     # Punt_epaae_avg = mean(punt_epa_above_expected),
-                     # Punt_epaae_tot = sum(punt_epa_above_expected),
                      Punt_eaepaae_avg = mean(pEPA),
+                     pEPA = mean(pEPA),
                      Punt_eaepaae_tot = sum(pEPA),
                      returnpct = mean(returned),
                      first_year = min(season),
                      last_year = max(season),
                      team_logo_espn = getmode_local(team_logo_espn),
                      team_color = getmode_local(team_color),
-                     team_color2 = getmode_local(team_color2)
+                     team_color2 = getmode_local(team_color2),
+                     ...
     )
   return(mini)
 }
@@ -55,17 +54,18 @@ create_mini <- function(punts, threshold=64) {
 #' which includes all of the relevant columns from a \code{puntr}-style data frame.
 #' This function differs from \code{puntr::create_mini}
 #' in that it groups by both \code{punter_player_name} and \code{season} (and adds a convenient \code{seasonid} column to uniquely identify each row).
-#' It is unfortunately not customizable beyond the setting of a minimum number of punts to be included;
-#' if you have additional parameters you'd like to be summarised, the easiest thing would be to call \code{summarise} yourself.
+#' NOTE: \code{puntr::create_mini}, \code{puntr::create_miniY}, and \code{puntr::create_miniG} are being phased out
+#' in favor of \code{puntr::by_punters}, \code{puntr::by_punter_seasons}, and \code{puntr::by_punter_games}
 #' @param punts The play-by-play punting data to be summarized
 #' @param threshold The minimum number of punts for a season to be included, defaults to 32
+#' @param ... Any additional arguments will be passed through to \code{dplyr::summarise}
 #' @return A tibble \code{miniY} where each row is a punter-season and each column is a stat
 #' @examples
 #' \dontrun{
 #' create_miniY(punts)
 #' }
 #' @export
-create_miniY <- function(punts, threshold=32) {
+create_miniY <- function(punts, ..., threshold=32) {
 
   mini <- punts %>%
     dplyr::group_by(punter_player_name, season) %>%
@@ -83,18 +83,14 @@ create_miniY <- function(punts, threshold=32) {
                      SHARP_RERUN = mean(SHARP_RERUN),
                      SHARP_RERUN_OF = mean(SHARP_RERUN_OF, na.rm = TRUE),
                      SHARP_RERUN_PD = mean(SHARP_RERUN_PD, na.rm = TRUE),
-                     # Punt_epa_avg = mean(punt_epa),
-                     # Punt_epa_tot = sum(punt_epa),
-                     # Punt_epaae_avg = mean(punt_epa_above_expected),
-                     # Punt_epaae_tot = sum(punt_epa_above_expected),
                      Punt_eaepaae_avg = mean(pEPA),
+                     pEPA = mean(pEPA),
                      Punt_eaepaae_tot = sum(pEPA),
                      returnpct = mean(returned),
-                     #returnpctpd = mean(returned_pd, na.rm = TRUE),
-                     #returnpctof = mean(returned_of, na.rm = TRUE),
                      team_logo_espn = getmode_local(team_logo_espn),
                      team_color = getmode_local(team_color),
-                     team_color2 = getmode_local(team_color2)
+                     team_color2 = getmode_local(team_color2),
+                     ...
     )
 
   mini <- mini %>%
@@ -109,17 +105,18 @@ create_miniY <- function(punts, threshold=32) {
 #' This function differs from \code{puntr::create_mini} and \code{puntr::create_miniY}
 #' in that it groups by \code{punter_player_name}, \code{season}, and \code{week}
 #' (and adds a convenient \code{weekid} column to uniquely identify each row).
-#' It is unfortunately not customizable beyond the setting of a minimum number of punts to be included;
-#' if you have additional parameters you'd like to be summarised, the easiest thing would be to call \code{summarise} yourself.
+#' NOTE: \code{puntr::create_mini}, \code{puntr::create_miniY}, and \code{puntr::create_miniG} are being phased out
+#' in favor of \code{puntr::by_punters}, \code{puntr::by_punter_seasons}, and \code{puntr::by_punter_games}
 #' @param punts The play-by-play punting data to be summarized
 #' @param threshold The minimum number of punts for a week to be included, defaults to 1
+#' @param ... Any additional arguments will be passed through to \code{dplyr::summarise}
 #' @return A tibble \code{miniG} where each row is a punter-week and each column is a stat
 #' @examples
 #' \dontrun{
 #' create_miniG(punts)
 #' }
 #' @export
-create_miniG <- function(punts, threshold=1) {
+create_miniG <- function(punts, ..., threshold=1) {
 
   mini <- punts %>%
     dplyr::group_by(punter_player_name, season, week) %>%
@@ -137,18 +134,14 @@ create_miniG <- function(punts, threshold=1) {
                      SHARP_RERUN = mean(SHARP_RERUN),
                      SHARP_RERUN_OF = mean(SHARP_RERUN_OF, na.rm = TRUE),
                      SHARP_RERUN_PD = mean(SHARP_RERUN_PD, na.rm = TRUE),
-                     # Punt_epa_avg = mean(punt_epa),
-                     # Punt_epa_tot = sum(punt_epa),
-                     # Punt_epaae_avg = mean(punt_epa_above_expected),
-                     # Punt_epaae_tot = sum(punt_epa_above_expected),
                      Punt_eaepaae_avg = mean(pEPA),
+                     pEPA = mean(pEPA),
                      Punt_eaepaae_tot = sum(pEPA),
                      returnpct = mean(returned),
-                     #returnpctpd = mean(returned_pd, na.rm = TRUE),
-                     #returnpctof = mean(returned_of, na.rm = TRUE),
                      team_logo_espn = getmode_local(team_logo_espn),
                      team_color = getmode_local(team_color),
-                     team_color2 = getmode_local(team_color2)
+                     team_color2 = getmode_local(team_color2),
+                     ...
     )
 
   mini <- mini %>%

--- a/R/mini2.R
+++ b/R/mini2.R
@@ -1,0 +1,108 @@
+###|
+###| "Mini2" section (NEW VERSION)
+###| Create a dataframe where each punter appears once
+###|
+
+#' Summarize data for player careers
+#' @description This function is essentially a convenient wrapper for \code{dplyr::summarise}
+#' which provides a dataframe with the following columns: NumPunts, pEPA, Gross, Net, RERUN, SHARP_RERUN_OF, SHARP_RERUN_PD,
+#' first_year, last_year, team_logo_espn, team_color, team_color2. Additional columns may be added via valid calls to \code{dplyr::summarise}
+#' as additional arguments.
+#' For comparison of punter seasons, see \code{puntr::by_punter_seasons}; for comparison of punter games, see \code{puntr::by_punter_games}.
+#' @param punts The play-by-play punting data to be summarized
+#' @param threshold The minimum number of career punts needed to be included, defaults to 64
+#' @param ... Any additional arguments will be passed through to \code{dplyr::summarise}
+#' @return A tibble \code{punters} where each row is a punter and each column is a stat
+#' @examples
+#' \dontrun{
+#' create_mini(punts)
+#' }
+#' @export
+by_punters <- function(punts, ..., threshold=64) {
+
+  punters <- punts %>%
+    dplyr::group_by(punter_player_name) %>%
+    dplyr::filter(dplyr::n() > threshold) %>%
+    custom_summary(...,
+                   first_year = min(season),
+                   last_year = max(season))
+
+  return(punters)
+}
+
+#' Summarize data for player-seasons
+#' @description This function is essentially a convenient wrapper for \code{dplyr::summarise}
+#' which includes all of the relevant columns from a \code{puntr}-style data frame.
+#' This function differs from \code{puntr::create_mini}
+#' in that it groups by both \code{punter_player_name} and \code{season} (and adds a convenient \code{seasonid} column to uniquely identify each row).
+#' It is unfortunately not customizable beyond the setting of a minimum number of punts to be included;
+#' if you have additional parameters you'd like to be summarised, the easiest thing would be to call \code{summarise} yourself.
+#' @param punts The play-by-play punting data to be summarized
+#' @param threshold The minimum number of punts for a season to be included, defaults to 32
+#' @return A tibble \code{miniY} where each row is a punter-season and each column is a stat
+#' @examples
+#' \dontrun{
+#' create_miniY(punts)
+#' }
+#' @export
+by_punter_seasons <- function(punts, ..., threshold=32) {
+
+  seasons <- punts %>%
+    dplyr::group_by(punter_player_name, season) %>%
+    dplyr::filter(dplyr::n() > threshold) %>%
+    custom_summary(...)
+
+  seasons <- seasons %>%
+    dplyr::mutate(seasonid = purrr::map2_chr(punter_player_name, season, glue::glue, .sep=" "))
+
+  return(seasons)
+}
+
+#' Summarize data for player-games
+#' @description This function is essentially a convenient wrapper for \code{dplyr::summarise}
+#' which includes all of the relevant columns from a \code{puntr}-style data frame.
+#' This function differs from \code{puntr::create_mini} and \code{puntr::create_miniY}
+#' in that it groups by \code{punter_player_name}, \code{season}, and \code{week}
+#' (and adds a convenient \code{weekid} column to uniquely identify each row).
+#' It is unfortunately not customizable beyond the setting of a minimum number of punts to be included;
+#' if you have additional parameters you'd like to be summarised, the easiest thing would be to call \code{summarise} yourself.
+#' @param punts The play-by-play punting data to be summarized
+#' @param threshold The minimum number of punts for a week to be included, defaults to 1
+#' @return A tibble \code{miniG} where each row is a punter-week and each column is a stat
+#' @examples
+#' \dontrun{
+#' create_miniG(punts)
+#' }
+#' @export
+by_punter_games <- function(punts, ..., threshold=1) {
+
+  games <- punts %>%
+    dplyr::group_by(punter_player_name, season, week) %>%
+    dplyr::filter(dplyr::n() >= threshold) %>%
+    custom_summary(...)
+
+  games <- games %>%
+    dplyr::mutate(weekid = purrr::pmap_chr(list(punter_player_name, ' ', season, ' w', week), glue::glue))
+
+  return(games)
+}
+
+custom_summary <- function(data, ...) {
+  .summary <- data %>%
+    dplyr::summarize(NumPunts = dplyr::n(),
+                     pEPA = mean(pEPA),
+                     Gross = mean(GrossYards),
+                     Net = mean(NetYards),
+                     RERUN = mean(RERUN),
+                     SHARP_RERUN_OF = mean(SHARP_RERUN_OF, na.rm = TRUE),
+                     SHARP_RERUN_PD = mean(SHARP_RERUN_PD, na.rm = TRUE),
+                     ...,
+                     team = getmode_local(posteam)
+  )
+  return(.summary)
+}
+
+getmode_local <- function(v) {
+  uniqv <- unique(v)
+  uniqv[which.max(tabulate(match(v, uniqv)))]
+}

--- a/R/mini2.R
+++ b/R/mini2.R
@@ -97,7 +97,10 @@ custom_summary <- function(data, ...) {
                      SHARP_RERUN_OF = mean(SHARP_RERUN_OF, na.rm = TRUE),
                      SHARP_RERUN_PD = mean(SHARP_RERUN_PD, na.rm = TRUE),
                      ...,
-                     team = getmode_local(posteam)
+                     team = getmode_local(posteam),
+                     team_logo_espn = getmode_local(team_logo_espn),
+                     team_color = getmode_local(team_color),
+                     team_color2 = getmode_local(team_color2),
   )
   return(.summary)
 }

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(puntr)
+
+test_check("puntr")

--- a/tests/testthat/test-mini.R
+++ b/tests/testthat/test-mini.R
@@ -1,0 +1,3 @@
+test_that("multiplication works", {
+  expect_equal(2 * 2, 4)
+})

--- a/vignettes/puntr.Rmd
+++ b/vignettes/puntr.Rmd
@@ -53,35 +53,53 @@ dbDisconnect(connection)
 ```
 
 ### Comparing punters
-To compare punters, continue with
+***Note***: New in `puntr 1.3`, the functions
+
+* `puntr::create_mini()`
+* `puntr::create_miniY()`
+* `puntr::create_miniG()` 
+
+are now deprecated, in favor of 
+
+ - `puntr::by_punters()`
+ - `puntr::by_punter_seasons()`
+ - `puntr::by_punter_games()`  
+
+To compare punters, use
 ```{r}
-mini <- create_mini(punts)
+punters <- by_punters(punts)
 ```
-to get a dataframe where each row is a punter, and each column is an average stat for that punter. There are many columns in this dataframe, but here's a few of the most interesting:  
+to get a dataframe where each row is a punter, and each column is an average stat for that punter. The most common standard and Punt Runts stats are included by default, but you can add whatever you like by passing additional arguments to `dplyr::summarize()`. For example:
 ```{r}
-mini <- mini %>% arrange(desc(Punt_eaepaae_avg)) %>% select(punter_player_name, Gross, Net, SHARP_RERUN, Punt_eaepaae_avg)
-rmarkdown::paged_table(mini)
+punters_custom <- by_punters(punts, longest_punt = max(GrossYards))
+```
+Let's take a look at some of the columns in this data frame:  
+```{r}
+punters %>% 
+  arrange(desc(pEPA)) %>% 
+  select(punter_player_name, Gross, Net, pEPA) %>%
+  rmarkdown::paged_table()
 ```
 To compare punter **seasons**, instead use
 ```{r}
-miniY <- create_miniY(punts)
+punter_seasons <- by_punter_seasons(punts)
 ```
 which gives every unique punter season a row.  
 ```{r, echo=FALSE}
-miniY <- miniY %>% arrange(desc(Punt_eaepaae_avg))
-rmarkdown::paged_table(miniY)
+punter_seasons %>%
+  arrange(desc(pEPA)) %>%
+  select(punter_player_name, season, Gross, Net, pEPA) %>%
+  rmarkdown::paged_table()
 ```
-To compare punter **games**, instead use
+And finally, to compare punter **games**, use
 ```{r}
-miniG <- create_miniG(punts)
+punter_games <- by_punter_games(punts)
 ```
 which gives every unique punter game a row.  
-```{r, echo=FALSE}
-miniG <- miniG %>% arrange(desc(Punt_eaepaae_avg))
-rmarkdown::paged_table(miniG)
-```
+
+**Note**: If a career, season, or game you're looking for is missing from your dataframe, try changing the `threshold = ` parameter to require fewer punts.
   
-These dataframes - `punts`, `mini`, `miniY` and `miniG` - should serve as a good starting point for any custom analysis you'd like to do, be that using built-in `puntr` metrics, or your own.
+These dataframes - `punts`, `punters`, `punter_seasons` and `punter_games` - should serve as a good starting point for any custom analysis you'd like to do, be that using built-in `puntr` metrics, or your own.
 
 ## Using `puntr` with college data
 ***NOTE: `puntr` currently does not work with college data, as migration from `cfbscrapR` to `cfbfastR` is ongoing.***


### PR DESCRIPTION
Officially (soft) deprecating the `mini_` family of functions in favor of the new `by_` family, which include fewer arguments by default, but allow customization by passing `...` argument through to `dplyr::summarize()`. `by_` functions also include the team name, which will facilitate migration to `nflplotR`.

This change is accompanied by incrementing to `puntr 1.3`.

NOTE: there is a merge conflict here with `puntr.rmd` because the college section of the vignette has changed. This will not be an issue.